### PR TITLE
fix: adding sizes element

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,6 @@
 </head>
 <body>
 <img src="https://tom.imgix.net/api/films/r1.png" srcset="https://tom.imgix.net/api/films/r1.png?w=400 1x, https://tom.imgix.net/api/films/r1.png?w=400&dpr=2 2x, https://tom.imgix.net/api/films/r1.png?w=400&dpr=3 3x">
-<img class="gallery" src="https://tom.imgix.net/api/films/r1.png" srcset="https://tom.imgix.net/api/films/r1.png?w=600 600w, https://tom.imgix.net/api/films/r1.png?w=1200 1200w, https://tom.imgix.net/api/films/r1.png?w=1500 1500w, https://tom.imgix.net/api/films/r1.png?w=1800 1800w">
+<img class="gallery" src="https://tom.imgix.net/api/films/r1.png" srcset="https://tom.imgix.net/api/films/r1.png?w=600 600w, https://tom.imgix.net/api/films/r1.png?w=1200 1200w, https://tom.imgix.net/api/films/r1.png?w=1500 1500w, https://tom.imgix.net/api/films/r1.png?w=1800 1800w" sizes="(max-width: 800px) 100vw, 600px">
 </body>
 </html>


### PR DESCRIPTION
adding sizes element to load correct sizes images. Without a sizes element, loads the largest srcset image.